### PR TITLE
Make r11 syncable

### DIFF
--- a/snippets/stag.xml
+++ b/snippets/stag.xml
@@ -11,10 +11,6 @@
            revision="r11"
            fetch="https://github.com/StagOS/"  />
 
-  <remote  name="gitea-stag"
-           revision="r11"
-           fetch="https://git.stag-os.org/StagOS/"  />
-
   <remote  name="gitlab-stag"
            revision="r11"
            fetch="https://gitlab.com/StagOS/"  />
@@ -27,7 +23,7 @@
 <include name="snippets/remove.xml" />
 
 <!-- Build first -->
- <project path="build/make" name="android_build_make" remote="gitea-stag" >
+ <project path="build/make" name="android_build_make" remote="stag" >
         <copyfile src="core/root.mk" dest="Makefile" />
         <linkfile src="CleanSpec.mk" dest="build/CleanSpec.mk" />
         <linkfile src="buildspec.mk.default" dest="build/buildspec.mk.default" />
@@ -37,29 +33,29 @@
         <linkfile src="tools" dest="build/tools" />      
  </project>
 
- <project path="build/soong" name="android_build_soong" remote="gitea-stag" >
+ <project path="build/soong" name="android_build_soong" remote="stag" >
         <linkfile src="root.bp" dest="Android.bp" />
         <linkfile src="bootstrap.bash" dest="bootstrap.bash" />
  </project>
  <project path="build/blueprint" name="android_build_blueprint" remote="stag" />
 
   <!-- Now to track with elegance -->
-  <project path="frameworks/av" name="android_frameworks_av" remote="gitea-stag" />
-  <project path="frameworks/base" name="android_frameworks_base" remote="gitea-stag" />
-  <project path="frameworks/native" name="android_frameworks_native" remote="gitea-stag" />
+  <project path="frameworks/av" name="android_frameworks_av" remote="stag" />
+  <project path="frameworks/base" name="android_frameworks_base" remote="stag" />
+  <project path="frameworks/native" name="android_frameworks_native" remote="stag" />
   <project path="frameworks/opt/net/ims" name="android_frameworks_opt_net_ims" remote="stag" />
   <project path="frameworks/opt/telephony" name="android_frameworks_opt_telephony" remote="stag" />
   <project path="bionic" name="android_bionic" remote="stag" />
   <project path="bootable/recovery" name="android_bootable_recovery" remote="stag" />
-  <project path="device/lineage/sepolicy" name="android_device_stag_sepolicy" remote="gitea-stag" />
+  <project path="device/lineage/sepolicy" name="android_device_stag_sepolicy" remote="stag" />
   <project path="hardware/libhardware_legacy" name="android_hardware_libhardware_legacy" remote="stag" />
   <project path="hardware/libhardware" name="android_hardware_libhardware" remote="stag" />
   <project path="hardware/interfaces" name="android_hardware_interfaces" remote="stag" />
   <project path="hardware/stag/interfaces" name="android_hardware_stag_interfaces" remote="stag" />
   <project path="hardware/qcom/wlan" name="android_hardware_qcom_wlan" remote="stag" />
   <project path="hardware/qcom-caf/wlan" name="android_hardware_qcom_wlan" remote="stag" revision="r11-caf" />
-  <project path="packages/apps/Settings" name="android_packages_apps_Settings" remote="gitea-stag" />
-  <project path="packages/apps/Horns" name="android_packages_apps_Horns" remote="gitea-stag" />
+  <project path="packages/apps/Settings" name="android_packages_apps_Settings" remote="stag" />
+  <project path="packages/apps/Horns" name="android_packages_apps_Horns" remote="stag" />
   <project path="packages/apps/FaceUnlockService" name="android_packages_apps_FaceUnlockService" remote="stag" />
   <project path="packages/apps/PotatoPlugins" name="android_packages_apps_PotatoPlugins" remote="stag" />
   <project path="packages/apps/Launcher3" name="android_packages_apps_Launcher3" remote="stag" />
@@ -72,10 +68,10 @@
   <project path="external/selinux" name="android_external_selinux" remote="stag" />
   <project path="external/tinycompress" name="android_external_tinycompress" remote="stag" /> 
   <project path="external/asus/stitchimage" name="android_external_asus_stitchimage" remote="stag" /> 
-  <project path="system/core" name="android_system_core" remote="gitea-stag" />
+  <project path="system/core" name="android_system_core" remote="stag" />
   <project path="system/vold" name="android_system_vold" remote="stag" />
   <project path="system/netd" name="android_system_netd" remote="stag" />
-  <project path="vendor/stag" name="android_vendor_stag" remote="gitea-stag" />
+  <project path="vendor/stag" name="android_vendor_stag" remote="stag" />
   <project path="system/sepolicy" name="android_system_sepolicy" remote="stag" />
   <project path="system/bt" name="android_system_bt" remote="stag" />
   <project path="system/update_engine" name="android_system_update_engine" remote="stag" />
@@ -92,6 +88,6 @@
   <project path="external/faceunlock" name="external_faceunlock" remote="gitlab-stag" />
 
   <!-- Gapps -->
-  <project path="vendor/gms" name="android_vendor_gms" remote="gitea-stag" clone-depth="1" />
+  <project path="vendor/gms" name="android_vendor_gms" remote="stag" clone-depth="1" />
 </manifest>
 


### PR DESCRIPTION
stag.xml in snippets contained an old, invalid remote called 'gitea-stag' with the URL, https://git.stag-os.org/StagOS/. This URL is non-existent it seems and repo cannot sync the tree properly with the old remote. I removed the old remote and changed the remote names for projects that relied on the old remote to the normal 'stag' remote.